### PR TITLE
Change Endless Ammo to Non-Consumable

### DIFF
--- a/Items/Weapons/Endless/EndlessArrowBunny.cs
+++ b/Items/Weapons/Endless/EndlessArrowBunny.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 10;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowCactus.cs
+++ b/Items/Weapons/Endless/EndlessArrowCactus.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowDrugged.cs
+++ b/Items/Weapons/Endless/EndlessArrowDrugged.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 10;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowIce.cs
+++ b/Items/Weapons/Endless/EndlessArrowIce.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 20;
             item.rare = ItemRarityID.Orange;
@@ -28,10 +27,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowMarked.cs
+++ b/Items/Weapons/Endless/EndlessArrowMarked.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 1f;
             item.value = 250;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowRubber.cs
+++ b/Items/Weapons/Endless/EndlessArrowRubber.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 10f; 
             item.value = 15;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowSand.cs
+++ b/Items/Weapons/Endless/EndlessArrowSand.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowSlime.cs
+++ b/Items/Weapons/Endless/EndlessArrowSlime.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Green;
@@ -30,10 +29,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowSpectral.cs
+++ b/Items/Weapons/Endless/EndlessArrowSpectral.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15; 
             item.rare = ItemRarityID.Orange;
@@ -28,10 +27,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessArrowTrueChloro.cs
+++ b/Items/Weapons/Endless/EndlessArrowTrueChloro.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 1f;
             item.value = 20;
             item.rare = ItemRarityID.Lime;
@@ -28,10 +27,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletBunny.cs
+++ b/Items/Weapons/Endless/EndlessBulletBunny.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 25;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletCactus.cs
+++ b/Items/Weapons/Endless/EndlessBulletCactus.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletDrugged.cs
+++ b/Items/Weapons/Endless/EndlessBulletDrugged.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 50;
             item.rare = ItemRarityID.Green;
@@ -28,10 +27,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletIce.cs
+++ b/Items/Weapons/Endless/EndlessBulletIce.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 10;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletMarked.cs
+++ b/Items/Weapons/Endless/EndlessBulletMarked.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 250;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletMiner.cs
+++ b/Items/Weapons/Endless/EndlessBulletMiner.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 25;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletRubber.cs
+++ b/Items/Weapons/Endless/EndlessBulletRubber.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 10f; 
             item.value = 25; 
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletSand.cs
+++ b/Items/Weapons/Endless/EndlessBulletSand.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletSlime.cs
+++ b/Items/Weapons/Endless/EndlessBulletSlime.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15;
             item.rare = ItemRarityID.Green;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletSpectral.cs
+++ b/Items/Weapons/Endless/EndlessBulletSpectral.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 50;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessBulletStarfall.cs
+++ b/Items/Weapons/Endless/EndlessBulletStarfall.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 10;
             item.rare = ItemRarityID.Green;
@@ -28,10 +27,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartAcupuncture.cs
+++ b/Items/Weapons/Endless/EndlessDartAcupuncture.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15;
             item.rare = ItemRarityID.Orange;
@@ -30,10 +29,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartBunny.cs
+++ b/Items/Weapons/Endless/EndlessDartBunny.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 25;
             item.rare = ItemRarityID.Orange;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartCactus.cs
+++ b/Items/Weapons/Endless/EndlessDartCactus.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 10;
             item.rare = ItemRarityID.Orange;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartDrugged.cs
+++ b/Items/Weapons/Endless/EndlessDartDrugged.cs
@@ -3,36 +3,36 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace AmmoboxPlus.Items.Weapons {
-    public class EndlessDartDrugged : ModItem {
-        public override void SetStaticDefaults() {
-            DisplayName.SetDefault("Endless Drugged Pouch");
-            Tooltip.SetDefault("Creates an aura around an enemy that damages nearby enemies");
-        }
+	public class EndlessDartDrugged : ModItem
+	{
+		public override void SetStaticDefaults()
+		{
+			DisplayName.SetDefault("Endless Drugged Pouch");
+			Tooltip.SetDefault("Creates an aura around an enemy that damages nearby enemies");
+		}
 
-        public override void SetDefaults() {
-            item.damage = 9;
-            item.ranged = true;
-            item.width = 8;
-            item.height = 8;
-            item.maxStack = 1;
-            item.consumable = true;
-            item.knockBack = 2f; 
-            item.value = 10;
-            item.rare = ItemRarityID.Orange;
-            item.shoot = mod.ProjectileType("DartDrugged");
-            item.shootSpeed = 2f;
-            item.ammo = AmmoID.Dart;
-        }
-        public override void AddRecipes() {
-            ModRecipe recipe = new ModRecipe(mod);
-            recipe.AddIngredient(mod.ItemType("DartDrugged"), 3996);
-            recipe.SetResult(this, 1);
-            recipe.AddTile(TileID.CrystalBall);
-            recipe.AddRecipe();
-        }
+		public override void SetDefaults()
+		{
+			item.damage = 9;
+			item.ranged = true;
+			item.width = 8;
+			item.height = 8;
+			item.maxStack = 1;
+			item.knockBack = 2f;
+			item.value = 10;
+			item.rare = ItemRarityID.Orange;
+			item.shoot = mod.ProjectileType("DartDrugged");
+			item.shootSpeed = 2f;
+			item.ammo = AmmoID.Dart;
+		}
 
-        public override bool ConsumeAmmo(Player player){
-            return false;
-        }
-    }
+		public override void AddRecipes()
+		{
+			ModRecipe recipe = new ModRecipe(mod);
+			recipe.AddIngredient(mod.ItemType("DartDrugged"), 3996);
+			recipe.SetResult(this, 1);
+			recipe.AddTile(TileID.CrystalBall);
+			recipe.AddRecipe();
+		}
+	}
 }

--- a/Items/Weapons/Endless/EndlessDartDrugged.cs
+++ b/Items/Weapons/Endless/EndlessDartDrugged.cs
@@ -3,16 +3,13 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace AmmoboxPlus.Items.Weapons {
-    public class EndlessDartDrugged : ModItem
-    {
-        public override void SetStaticDefaults()
-        {
+    public class EndlessDartDrugged : ModItem {
+        public override void SetStaticDefaults() {
             DisplayName.SetDefault("Endless Drugged Pouch");
             Tooltip.SetDefault("Creates an aura around an enemy that damages nearby enemies");
         }
 
-        public override void SetDefaults()
-        {
+        public override void SetDefaults() {
             item.damage = 9;
             item.ranged = true;
             item.width = 8;
@@ -26,8 +23,7 @@ namespace AmmoboxPlus.Items.Weapons {
             item.ammo = AmmoID.Dart;
         }
 
-        public override void AddRecipes()
-        {
+        public override void AddRecipes() {
             ModRecipe recipe = new ModRecipe(mod);
             recipe.AddIngredient(mod.ItemType("DartDrugged"), 3996);
             recipe.SetResult(this, 1);

--- a/Items/Weapons/Endless/EndlessDartDrugged.cs
+++ b/Items/Weapons/Endless/EndlessDartDrugged.cs
@@ -3,36 +3,36 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace AmmoboxPlus.Items.Weapons {
-	public class EndlessDartDrugged : ModItem
-	{
-		public override void SetStaticDefaults()
-		{
-			DisplayName.SetDefault("Endless Drugged Pouch");
-			Tooltip.SetDefault("Creates an aura around an enemy that damages nearby enemies");
-		}
+    public class EndlessDartDrugged : ModItem
+    {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Endless Drugged Pouch");
+            Tooltip.SetDefault("Creates an aura around an enemy that damages nearby enemies");
+        }
 
-		public override void SetDefaults()
-		{
-			item.damage = 9;
-			item.ranged = true;
-			item.width = 8;
-			item.height = 8;
-			item.maxStack = 1;
-			item.knockBack = 2f;
-			item.value = 10;
-			item.rare = ItemRarityID.Orange;
-			item.shoot = mod.ProjectileType("DartDrugged");
-			item.shootSpeed = 2f;
-			item.ammo = AmmoID.Dart;
-		}
+        public override void SetDefaults()
+        {
+            item.damage = 9;
+            item.ranged = true;
+            item.width = 8;
+            item.height = 8;
+            item.maxStack = 1;
+            item.knockBack = 2f;
+            item.value = 10;
+            item.rare = ItemRarityID.Orange;
+            item.shoot = mod.ProjectileType("DartDrugged");
+            item.shootSpeed = 2f;
+            item.ammo = AmmoID.Dart;
+        }
 
-		public override void AddRecipes()
-		{
-			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(mod.ItemType("DartDrugged"), 3996);
-			recipe.SetResult(this, 1);
-			recipe.AddTile(TileID.CrystalBall);
-			recipe.AddRecipe();
-		}
-	}
+        public override void AddRecipes()
+        {
+            ModRecipe recipe = new ModRecipe(mod);
+            recipe.AddIngredient(mod.ItemType("DartDrugged"), 3996);
+            recipe.SetResult(this, 1);
+            recipe.AddTile(TileID.CrystalBall);
+            recipe.AddRecipe();
+        }
+    }
 }

--- a/Items/Weapons/Endless/EndlessDartFrostburn.cs
+++ b/Items/Weapons/Endless/EndlessDartFrostburn.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 10;
             item.rare = ItemRarityID.Orange;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartIce.cs
+++ b/Items/Weapons/Endless/EndlessDartIce.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 20; 
             item.rare = ItemRarityID.Orange;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartMarked.cs
+++ b/Items/Weapons/Endless/EndlessDartMarked.cs
@@ -3,36 +3,36 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace AmmoboxPlus.Items.Weapons {
-	public class EndlessDartMarked : ModItem
-	{
-		public override void SetStaticDefaults()
-		{
-			DisplayName.SetDefault("Endless Marker Pouch");
-			Tooltip.SetDefault("Inflicts 'Marked for Death'.\nInflicted enemies receive 15% more damage.");
-		}
+    public class EndlessDartMarked : ModItem
+    {
+        public override void SetStaticDefaults()
+        {
+            DisplayName.SetDefault("Endless Marker Pouch");
+            Tooltip.SetDefault("Inflicts 'Marked for Death'.\nInflicted enemies receive 15% more damage.");
+        }
 
-		public override void SetDefaults()
-		{
-			item.damage = 2;
-			item.ranged = true;
-			item.width = 8;
-			item.height = 8;
-			item.maxStack = 1;
-			item.knockBack = 1f;
-			item.value = 250;
-			item.rare = ItemRarityID.Lime;
-			item.shoot = mod.ProjectileType("DartMarked");
-			item.shootSpeed = 9f;
-			item.ammo = AmmoID.Dart;
-		}
+        public override void SetDefaults()
+        {
+            item.damage = 2;
+            item.ranged = true;
+            item.width = 8;
+            item.height = 8;
+            item.maxStack = 1;
+            item.knockBack = 1f;
+            item.value = 250;
+            item.rare = ItemRarityID.Lime;
+            item.shoot = mod.ProjectileType("DartMarked");
+            item.shootSpeed = 9f;
+            item.ammo = AmmoID.Dart;
+        }
 
-		public override void AddRecipes()
-		{
-			ModRecipe recipe = new ModRecipe(mod);
-			recipe.AddIngredient(mod.ItemType("DartMarked"), 50);
-			recipe.SetResult(this, 1);
-			recipe.AddTile(TileID.CrystalBall);
-			recipe.AddRecipe();
-		}
-	}
+        public override void AddRecipes()
+        {
+            ModRecipe recipe = new ModRecipe(mod);
+            recipe.AddIngredient(mod.ItemType("DartMarked"), 50);
+            recipe.SetResult(this, 1);
+            recipe.AddTile(TileID.CrystalBall);
+            recipe.AddRecipe();
+        }
+    }
 }

--- a/Items/Weapons/Endless/EndlessDartMarked.cs
+++ b/Items/Weapons/Endless/EndlessDartMarked.cs
@@ -3,36 +3,36 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace AmmoboxPlus.Items.Weapons {
-    public class EndlessDartMarked : ModItem {
-        public override void SetStaticDefaults() {
-            DisplayName.SetDefault("Endless Marker Pouch");
-            Tooltip.SetDefault("Inflicts 'Marked for Death'.\nInflicted enemies receive 15% more damage.");
-        }
+	public class EndlessDartMarked : ModItem
+	{
+		public override void SetStaticDefaults()
+		{
+			DisplayName.SetDefault("Endless Marker Pouch");
+			Tooltip.SetDefault("Inflicts 'Marked for Death'.\nInflicted enemies receive 15% more damage.");
+		}
 
-        public override void SetDefaults() {
-            item.damage = 2;
-            item.ranged = true;
-            item.width = 8;
-            item.height = 8;
-            item.maxStack = 1;
-            item.consumable = true;
-            item.knockBack = 1f; 
-            item.value = 250; 
-            item.rare = ItemRarityID.Lime;
-            item.shoot = mod.ProjectileType("DartMarked");
-            item.shootSpeed = 9f;
-            item.ammo = AmmoID.Dart;
-        }
-        public override void AddRecipes() {
-            ModRecipe recipe = new ModRecipe(mod);
-            recipe.AddIngredient(mod.ItemType("DartMarked"), 50);
-            recipe.SetResult(this, 1);
-            recipe.AddTile(TileID.CrystalBall);
-            recipe.AddRecipe();
-        }
+		public override void SetDefaults()
+		{
+			item.damage = 2;
+			item.ranged = true;
+			item.width = 8;
+			item.height = 8;
+			item.maxStack = 1;
+			item.knockBack = 1f;
+			item.value = 250;
+			item.rare = ItemRarityID.Lime;
+			item.shoot = mod.ProjectileType("DartMarked");
+			item.shootSpeed = 9f;
+			item.ammo = AmmoID.Dart;
+		}
 
-        public override bool ConsumeAmmo(Player player){
-            return false;
-        }
-    }
+		public override void AddRecipes()
+		{
+			ModRecipe recipe = new ModRecipe(mod);
+			recipe.AddIngredient(mod.ItemType("DartMarked"), 50);
+			recipe.SetResult(this, 1);
+			recipe.AddTile(TileID.CrystalBall);
+			recipe.AddRecipe();
+		}
+	}
 }

--- a/Items/Weapons/Endless/EndlessDartMarked.cs
+++ b/Items/Weapons/Endless/EndlessDartMarked.cs
@@ -3,16 +3,13 @@ using Terraria.ID;
 using Terraria.ModLoader;
 
 namespace AmmoboxPlus.Items.Weapons {
-    public class EndlessDartMarked : ModItem
-    {
-        public override void SetStaticDefaults()
-        {
+    public class EndlessDartMarked : ModItem {
+        public override void SetStaticDefaults() {
             DisplayName.SetDefault("Endless Marker Pouch");
             Tooltip.SetDefault("Inflicts 'Marked for Death'.\nInflicted enemies receive 15% more damage.");
         }
 
-        public override void SetDefaults()
-        {
+        public override void SetDefaults() {
             item.damage = 2;
             item.ranged = true;
             item.width = 8;
@@ -26,8 +23,7 @@ namespace AmmoboxPlus.Items.Weapons {
             item.ammo = AmmoID.Dart;
         }
 
-        public override void AddRecipes()
-        {
+        public override void AddRecipes() {
             ModRecipe recipe = new ModRecipe(mod);
             recipe.AddIngredient(mod.ItemType("DartMarked"), 50);
             recipe.SetResult(this, 1);

--- a/Items/Weapons/Endless/EndlessDartSand.cs
+++ b/Items/Weapons/Endless/EndlessDartSand.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15;
             item.rare = ItemRarityID.Orange;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartSlime.cs
+++ b/Items/Weapons/Endless/EndlessDartSlime.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15;
             item.rare = ItemRarityID.Orange;
@@ -30,10 +29,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartStarfall.cs
+++ b/Items/Weapons/Endless/EndlessDartStarfall.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 15;
             item.rare = ItemRarityID.Orange;
@@ -28,10 +27,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartYang.cs
+++ b/Items/Weapons/Endless/EndlessDartYang.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 150; 
             item.rare = ItemRarityID.Orange;
@@ -30,10 +29,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessDartYing.cs
+++ b/Items/Weapons/Endless/EndlessDartYing.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 8;
             item.height = 8;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f; 
             item.value = 150; 
             item.rare = ItemRarityID.Orange;
@@ -30,10 +29,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketBlackhole.cs
+++ b/Items/Weapons/Endless/EndlessRocketBlackhole.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -30,10 +29,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketBunny.cs
+++ b/Items/Weapons/Endless/EndlessRocketBunny.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketChlorophyte.cs
+++ b/Items/Weapons/Endless/EndlessRocketChlorophyte.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketCursed.cs
+++ b/Items/Weapons/Endless/EndlessRocketCursed.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketFrostburn.cs
+++ b/Items/Weapons/Endless/EndlessRocketFrostburn.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketGolemfist.cs
+++ b/Items/Weapons/Endless/EndlessRocketGolemfist.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketHarpy.cs
+++ b/Items/Weapons/Endless/EndlessRocketHarpy.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketHeart.cs
+++ b/Items/Weapons/Endless/EndlessRocketHeart.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -30,10 +29,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketIce.cs
+++ b/Items/Weapons/Endless/EndlessRocketIce.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketIchor.cs
+++ b/Items/Weapons/Endless/EndlessRocketIchor.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketMiner.cs
+++ b/Items/Weapons/Endless/EndlessRocketMiner.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketSand.cs
+++ b/Items/Weapons/Endless/EndlessRocketSand.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }

--- a/Items/Weapons/Endless/EndlessRocketStarburst.cs
+++ b/Items/Weapons/Endless/EndlessRocketStarburst.cs
@@ -15,7 +15,6 @@ namespace AmmoboxPlus.Items.Weapons {
             item.width = 20;
             item.height = 14;
             item.maxStack = 1;
-            item.consumable = true;
             item.knockBack = 2f;
             item.value = 15;
             item.rare = ItemRarityID.Lime;
@@ -29,10 +28,6 @@ namespace AmmoboxPlus.Items.Weapons {
             recipe.SetResult(this, 1);
             recipe.AddTile(TileID.CrystalBall);
             recipe.AddRecipe();
-        }
-
-        public override bool ConsumeAmmo(Player player){
-            return false;
         }
     }
 }


### PR DESCRIPTION
- Endless Ammo Items no longer override ConsumeAmmo
- Instead, they're not consumables
- Should fix problem with MechTransfer's OmniTurret (see #3 )

Sadly, I couldn't test, but I'll provide a test world in the issue.